### PR TITLE
PyPI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 exclude = __init__.py, conf.py
-ignore = E501, W503
+ignore = E501, W503, E402

--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@ repository.
 
 ## Installation
 
-There are a few options for installing this package. Once a PyPI version is
-cut, these instructions will be updated.
+The easiest way to install this package is with ``pip``:
 
+```bash
+pip install frispy
+```
+
+To install from source, there are other steps involved.
 First, you must obtain the code from Github. If you have
 [`git`](https://git-scm.com/) installed you can clone the repository from
 the command line:

--- a/frispy/__init__.py
+++ b/frispy/__init__.py
@@ -1,8 +1,9 @@
-from frispy.disc import Disc
-from frispy.environment import Environment
-from frispy.equations_of_motion import EOM
-from frispy.model import Model
-from frispy.trajectory import Trajectory
+from .disc import Disc
+from .environment import Environment
+from .equations_of_motion import EOM
+from .model import Model
+from .trajectory import Trajectory
 
 __author__ = "Tom McClintock thmsmcclintock@gmail.com"
-__version__ = "1.0.0"
+__version__ = "1.0.1"
+__docs__ = "Simulates flying spinning discs."

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,26 @@
-"""
-Setup file for the frispy package.
-"""
+import os
 
+PATH_ROOT = os.path.dirname(__file__)
 from setuptools import setup
 
+import frispy  # noqa: E402
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 setup(
-    name="FrisPy",
+    name="frispy",
     author="Tom McClintock",
     author_email="thmsmcclintock@gmail.com",
-    version="1.0.0",  # TODO: check version from init file
-    description="Simulated flying discs",
+    version=frispy.__version__,
+    description=frispy.__docs__,
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/tmcclintock/FrisPy",
     packages=["frispy"],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+    ],
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
Closes #6.

This PR puts frispy on PyPI (at least, it will once this is merged). It updates the `setup.py` script so that the README appears on PyPI as well.